### PR TITLE
Fix print_ldap_list to deal with non list entries

### DIFF
--- a/ad2openldap/ad2openldap3
+++ b/ad2openldap/ad2openldap3
@@ -1050,8 +1050,11 @@ def flatten_groups(groups,ugroups,users,dn_uid_map):
 def print_ldap_list(crud,attr):
     ldap_list = ''
     if exists(attr,crud):
-        for item in sorted(crud[attr]):
-            ldap_list += attr+": "+item+'\n'
+	if isinstance(crud[attr],list):
+            for item in sorted(crud[attr]):
+                ldap_list += attr+": "+item+'\n'
+	else:
+		ldap_list += attr+": "+crud[attr]+'\n'
     return ldap_list
 
 


### PR DESCRIPTION
Previous behavior broke previously seldom used entities like nisMaps, etc